### PR TITLE
Improve GA4 analytics tracking

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
+import { AnalyticsService } from './shared/analytics/analytics.service';
 
 @Component({
     selector: 'app-root',
@@ -11,13 +12,17 @@ import { filter } from 'rxjs/operators';
 export class AppComponent implements OnInit {
   title = 'invmetro-site';
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private analytics: AnalyticsService
+  ) {}
 
   ngOnInit() {
     this.router.events.pipe(
       filter(event => event instanceof NavigationEnd)
-    ).subscribe(() => {
+    ).subscribe((event) => {
       window.scrollTo(0, 0);
+      this.analytics.pageView(event.urlAfterRedirects);
     });
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { SobreComponent } from './sobre/sobre.component';
 import { FaqComponent } from './faq/faq.component';
 import { ContatoComponent } from './contato/contato.component';
 import {CommonModule, HashLocationStrategy, LocationStrategy} from "@angular/common";
+import { TrackClickDirective } from './shared/analytics/track-click.directive';
 
 @NgModule({
   declarations: [
@@ -26,7 +27,8 @@ import {CommonModule, HashLocationStrategy, LocationStrategy} from "@angular/com
     TableCampoLargoComponent,
     SobreComponent,
     FaqComponent,
-    ContatoComponent
+    ContatoComponent,
+    TrackClickDirective
   ],
   imports: [
     BrowserModule,

--- a/src/app/contato/contato.component.html
+++ b/src/app/contato/contato.component.html
@@ -6,10 +6,12 @@
         <h1 class="display-4 fw-bold text-white mb-4">Entre em Contato</h1>
         <p class="lead text-white-50 mb-4">Estamos prontos para atender você nas nossas duas unidades em Curitiba e Campo Largo.</p>
         <div class="d-flex gap-3">
-          <button (click)="scrollToSection('contato-rapido')" class="btn btn-light">
+          <button (click)="scrollToSection('contato-rapido')" class="btn btn-light" appTrackClick="select_content"
+                  [analyticsParams]="{ event_category: 'cta', event_label: 'Fale Conosco', content_type: 'section_scroll', page_section: 'contato_hero' }">
             <i class="fas fa-phone me-2"></i>Fale Conosco
           </button>
-          <button (click)="scrollToSection('localizacao')" class="btn btn-outline-light">
+          <button (click)="scrollToSection('localizacao')" class="btn btn-outline-light" appTrackClick="select_content"
+                  [analyticsParams]="{ event_category: 'cta', event_label: 'Localização', content_type: 'section_scroll', page_section: 'contato_hero' }">
             <i class="fas fa-map-marker-alt me-2"></i>Localização
           </button>
         </div>
@@ -43,10 +45,12 @@
             <h4 class="card-title mb-3">WhatsApp</h4>
             <p class="card-text text-muted mb-4">Fale conosco pelo WhatsApp para atendimento rápido</p>
             <div class="d-grid gap-2">
-              <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-success">
+              <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-success" appTrackClick="generate_lead"
+                 [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Contato Curitiba', contact_method: 'whatsapp', location: 'curitiba', page_section: 'contato_rapido' }">
                 <i class="fab fa-whatsapp me-2"></i>Curitiba: (41) 3357-3939
               </a>
-              <a href="https://api.whatsapp.com/send?phone=554135551300" class="btn btn-outline-success">
+              <a href="https://api.whatsapp.com/send?phone=554135551300" class="btn btn-outline-success" appTrackClick="generate_lead"
+                 [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Contato Campo Largo', contact_method: 'whatsapp', location: 'campo_largo', page_section: 'contato_rapido' }">
                 <i class="fab fa-whatsapp me-2"></i>Campo Largo: (41) 3555-1300
               </a>
             </div>
@@ -63,10 +67,12 @@
             <h4 class="card-title mb-3">E-mail</h4>
             <p class="card-text text-muted mb-4">Envie suas dúvidas por e-mail</p>
             <div class="d-grid gap-2">
-              <a href="mailto:invmetrocuritiba@gmail.com" class="btn btn-success">
+              <a href="mailto:invmetrocuritiba@gmail.com" class="btn btn-success" appTrackClick="generate_lead"
+                 [analyticsParams]="{ event_category: 'lead', event_label: 'E-mail Contato Curitiba', contact_method: 'email', location: 'curitiba', page_section: 'contato_rapido' }">
                 <i class="fas fa-envelope me-2"></i>invmetrocuritiba&#64;gmail.com
               </a>
-              <a href="mailto:invmetrocampolargo@gmail.com" class="btn btn-outline-success">
+              <a href="mailto:invmetrocampolargo@gmail.com" class="btn btn-outline-success" appTrackClick="generate_lead"
+                 [analyticsParams]="{ event_category: 'lead', event_label: 'E-mail Contato Campo Largo', contact_method: 'email', location: 'campo_largo', page_section: 'contato_rapido' }">
                 <i class="fas fa-envelope me-2"></i>invmetrocampolargo&#64;gmail.com
               </a>
             </div>
@@ -114,7 +120,8 @@
                 </div>
                 <div class="detail-content">
                   <h6>WhatsApp</h6>
-                  <p><a href="https://api.whatsapp.com/send?phone=554133573939" class="contact-link">(41) 3357-3939</a></p>
+                  <p><a href="https://api.whatsapp.com/send?phone=554133573939" class="contact-link" appTrackClick="generate_lead"
+                        [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Unidade Curitiba', contact_method: 'whatsapp', location: 'curitiba', page_section: 'contato_localizacao' }">(41) 3357-3939</a></p>
                 </div>
               </div>
               <div class="detail-item">
@@ -123,7 +130,8 @@
                 </div>
                 <div class="detail-content">
                   <h6>E-mail</h6>
-                  <p><a href="mailto:invmetrocuritiba@gmail.com" class="contact-link">invmetrocuritiba&#64;gmail.com</a></p>
+                  <p><a href="mailto:invmetrocuritiba@gmail.com" class="contact-link" appTrackClick="generate_lead"
+                        [analyticsParams]="{ event_category: 'lead', event_label: 'E-mail Unidade Curitiba', contact_method: 'email', location: 'curitiba', page_section: 'contato_localizacao' }">invmetrocuritiba&#64;gmail.com</a></p>
                 </div>
               </div>
             </div>
@@ -163,7 +171,8 @@
                 </div>
                 <div class="detail-content">
                   <h6>WhatsApp</h6>
-                  <p><a href="https://api.whatsapp.com/send?phone=554135551300" class="contact-link">(41) 3555-1300</a></p>
+                  <p><a href="https://api.whatsapp.com/send?phone=554135551300" class="contact-link" appTrackClick="generate_lead"
+                        [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Unidade Campo Largo', contact_method: 'whatsapp', location: 'campo_largo', page_section: 'contato_localizacao' }">(41) 3555-1300</a></p>
                 </div>
               </div>
               <div class="detail-item">
@@ -172,7 +181,8 @@
                 </div>
                 <div class="detail-content">
                   <h6>E-mail</h6>
-                  <p><a href="mailto:invmetrocampolargo@gmail.com" class="contact-link">invmetrocampolargo&#64;gmail.com</a></p>
+                  <p><a href="mailto:invmetrocampolargo@gmail.com" class="contact-link" appTrackClick="generate_lead"
+                        [analyticsParams]="{ event_category: 'lead', event_label: 'E-mail Unidade Campo Largo', contact_method: 'email', location: 'campo_largo', page_section: 'contato_localizacao' }">invmetrocampolargo&#64;gmail.com</a></p>
                 </div>
               </div>
             </div>
@@ -188,4 +198,3 @@
     </div>
   </div>
 </section>
-

--- a/src/app/faq/faq.component.html
+++ b/src/app/faq/faq.component.html
@@ -6,10 +6,12 @@
         <h1 class="display-4 fw-bold text-white mb-4">Perguntas Frequentes</h1>
         <p class="lead text-white-50 mb-4">Tire todas as suas dúvidas sobre nossos serviços de inspeção veicular.</p>
         <div class="d-flex gap-3">
-          <button (click)="scrollToSection('faq-content')" class="btn btn-light">
+          <button (click)="scrollToSection('faq-content')" class="btn btn-light" appTrackClick="select_content"
+                  [analyticsParams]="{ event_category: 'cta', event_label: 'Ver Perguntas', content_type: 'section_scroll', page_section: 'faq_hero' }">
             <i class="fas fa-question-circle me-2"></i>Ver Perguntas
           </button>
-          <a routerLink="/contato" class="btn btn-outline-light">
+          <a routerLink="/contato" class="btn btn-outline-light" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Fale Conosco FAQ Hero', content_type: 'internal_cta', page_section: 'faq_hero' }">
             <i class="fas fa-phone me-2"></i>Fale Conosco
           </a>
         </div>
@@ -41,7 +43,8 @@
             <!-- FAQ Item 1 -->
             <div class="faq-item">
               <div class="faq-header" id="faq1">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse1" aria-expanded="false" aria-controls="collapse1">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse1" aria-expanded="false" aria-controls="collapse1" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Vocês trabalham com agendamento?', faq_category: 'Agendamento e Pagamento' }">
                   <div class="faq-icon">
                     <i class="fas fa-calendar-alt"></i>
                   </div>
@@ -55,7 +58,8 @@
               </div>
               <div id="collapse1" class="collapse" aria-labelledby="faq1" data-bs-parent="#faqAccordion">
                 <div class="faq-body">
-                  <p>Sim, trabalhamos com agendamento para sua comodidade. <a routerLink="/contato" class="faq-link">Clique aqui para entrar em contato</a> e agendar sua inspeção.</p>
+                  <p>Sim, trabalhamos com agendamento para sua comodidade. <a routerLink="/contato" class="faq-link" appTrackClick="select_content"
+                                                                               [analyticsParams]="{ event_category: 'cta', event_label: 'Contato via FAQ Agendamento', content_type: 'internal_cta', page_section: 'faq_answer' }">Clique aqui para entrar em contato</a> e agendar sua inspeção.</p>
                 </div>
               </div>
             </div>
@@ -63,7 +67,8 @@
             <!-- FAQ Item 2 -->
             <div class="faq-item">
               <div class="faq-header" id="faq2">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse2" aria-expanded="false" aria-controls="collapse2">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse2" aria-expanded="false" aria-controls="collapse2" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Qual a forma de pagamento? Parcela?', faq_category: 'Agendamento e Pagamento' }">
                   <div class="faq-icon">
                     <i class="fas fa-credit-card"></i>
                   </div>
@@ -92,7 +97,8 @@
             <!-- FAQ Item 3 -->
             <div class="faq-item">
               <div class="faq-header" id="faq3">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse3" aria-expanded="false" aria-controls="collapse3">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse3" aria-expanded="false" aria-controls="collapse3" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Se o veículo reprovar, terei prazo?', faq_category: 'Processo de Inspeção' }">
                   <div class="faq-icon">
                     <i class="fas fa-redo-alt"></i>
                   </div>
@@ -115,7 +121,8 @@
             <!-- FAQ Item 4 -->
             <div class="faq-item">
               <div class="faq-header" id="faq4">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse4" aria-expanded="false" aria-controls="collapse4">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse4" aria-expanded="false" aria-controls="collapse4" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Qual o horário de funcionamento?', faq_category: 'Processo de Inspeção' }">
                   <div class="faq-icon">
                     <i class="fas fa-clock"></i>
                   </div>
@@ -146,7 +153,8 @@
             <!-- FAQ Item 5 -->
             <div class="faq-item">
               <div class="faq-header" id="faq5">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse5" aria-expanded="false" aria-controls="collapse5">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse5" aria-expanded="false" aria-controls="collapse5" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Quais itens são verificados na inspeção?', faq_category: 'Processo de Inspeção' }">
                   <div class="faq-icon">
                     <i class="fas fa-search"></i>
                   </div>
@@ -203,7 +211,8 @@
             <!-- FAQ Item 6 -->
             <div class="faq-item">
               <div class="faq-header" id="faq6">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse6" aria-expanded="false" aria-controls="collapse6">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse6" aria-expanded="false" aria-controls="collapse6" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Quais documentos são necessários?', faq_category: 'Documentação e Autorizações' }">
                   <div class="faq-icon">
                     <i class="fas fa-file-alt"></i>
                   </div>
@@ -263,7 +272,8 @@
             <!-- FAQ Item 7 -->
             <div class="faq-item">
               <div class="faq-header" id="faq7">
-                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse7" aria-expanded="false" aria-controls="collapse7">
+                <button class="faq-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse7" aria-expanded="false" aria-controls="collapse7" appTrackClick="faq_open"
+                        [analyticsParams]="{ event_category: 'faq', event_label: 'Preciso de autorização do DETRAN?', faq_category: 'Documentação e Autorizações' }">
                   <div class="faq-icon">
                     <i class="fas fa-stamp"></i>
                   </div>
@@ -315,10 +325,12 @@
         <h3 class="h4 mb-3">Ainda tem dúvidas?</h3>
         <p class="lead mb-4">Nossa equipe está pronta para ajudá-lo</p>
         <div class="d-flex gap-3 justify-content-center">
-          <a routerLink="/contato" class="btn btn-success">
+          <a routerLink="/contato" class="btn btn-success" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Entre em Contato FAQ', content_type: 'internal_cta', page_section: 'faq_cta' }">
             <i class="fas fa-phone me-2"></i>Entre em Contato
           </a>
-          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-outline-success">
+          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-outline-success" appTrackClick="generate_lead"
+             [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp FAQ CTA', contact_method: 'whatsapp', location: 'curitiba', page_section: 'faq_cta' }">
             <i class="fab fa-whatsapp me-2"></i>WhatsApp
           </a>
         </div>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -44,7 +44,8 @@
               <i class="fas fa-map-marker-alt"></i>
               <span>Estrada da Ribeira, 970 A<br>Bairro Atuba - Curitiba/PR</span>
             </div>
-            <a href="https://api.whatsapp.com/send?phone=554133573939" target="_blank" class="whatsapp-btn">
+            <a href="https://api.whatsapp.com/send?phone=554133573939" target="_blank" class="whatsapp-btn" appTrackClick="generate_lead"
+               [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Footer Curitiba', contact_method: 'whatsapp', location: 'curitiba', page_section: 'footer' }">
               <i class="fab fa-whatsapp"></i> WhatsApp
             </a>
           </div>
@@ -66,7 +67,8 @@
               <i class="fas fa-map-marker-alt"></i>
               <span>BR 277 Km 114, 25 A<br>Bairro Rondinha - Campo Largo/PR</span>
             </div>
-            <a href="https://api.whatsapp.com/send?phone=554135551300" target="_blank" class="whatsapp-btn">
+            <a href="https://api.whatsapp.com/send?phone=554135551300" target="_blank" class="whatsapp-btn" appTrackClick="generate_lead"
+               [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Footer Campo Largo', contact_method: 'whatsapp', location: 'campo_largo', page_section: 'footer' }">
               <i class="fab fa-whatsapp"></i> WhatsApp
             </a>
           </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -7,10 +7,12 @@
           <h1 class="hero-title">Inspeção Veicular com Qualidade e Confiança</h1>
           <p class="hero-subtitle">Mais de 16 anos de experiência em inspeções técnicas. Acreditada pela CGCRE e licenciada pelo SENATRAN para todo o Brasil.</p>
           <div class="hero-buttons">
-            <a class="btn btn-light btn-lg" routerLink="/contato">
+            <a class="btn btn-light btn-lg" routerLink="/contato" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'cta', event_label: 'Agendar Inspeção', content_type: 'internal_cta', page_section: 'home_hero' }">
               <i class="fas fa-calendar-alt me-2"></i>Agendar Inspeção
             </a>
-            <a class="btn btn-outline-light btn-lg" routerLink="/servicos">
+            <a class="btn btn-outline-light btn-lg" routerLink="/servicos" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'cta', event_label: 'Nossos Serviços', content_type: 'internal_cta', page_section: 'home_hero' }">
               <i class="fas fa-list me-2"></i>Nossos Serviços
             </a>
           </div>
@@ -113,7 +115,8 @@
               <li><i class="fas fa-check"></i> Inclusão e retirada do kit</li>
               <li><i class="fas fa-check"></i> Avaliação completa do sistema</li>
             </ul>
-            <a routerLink="/servicos" class="btn btn-success">
+            <a routerLink="/servicos" class="btn btn-success" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'service_card', event_label: 'Inspeção GNV', content_type: 'service_cta', page_section: 'home_services' }">
               <i class="fas fa-arrow-right me-2"></i>Saiba mais
             </a>
           </div>
@@ -133,7 +136,8 @@
               <li><i class="fas fa-check"></i> Regularização de bloqueios</li>
               <li><i class="fas fa-check"></i> Liberação para circulação</li>
             </ul>
-            <a routerLink="/servicos" class="btn btn-success">
+            <a routerLink="/servicos" class="btn btn-success" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'service_card', event_label: 'Veículo Sinistro', content_type: 'service_cta', page_section: 'home_services' }">
               <i class="fas fa-arrow-right me-2"></i>Saiba mais
             </a>
           </div>
@@ -153,7 +157,8 @@
               <li><i class="fas fa-check"></i> Modificações estruturais</li>
               <li><i class="fas fa-check"></i> Adaptações especiais</li>
             </ul>
-            <a routerLink="/servicos" class="btn btn-success">
+            <a routerLink="/servicos" class="btn btn-success" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'service_card', event_label: 'Veículo Modificado', content_type: 'service_cta', page_section: 'home_services' }">
               <i class="fas fa-arrow-right me-2"></i>Saiba mais
             </a>
           </div>
@@ -163,7 +168,8 @@
 
     <div class="row mt-4">
       <div class="col-12 text-center">
-        <a routerLink="/servicos" class="btn btn-outline-success btn-lg">
+        <a routerLink="/servicos" class="btn btn-outline-success btn-lg" appTrackClick="select_content"
+           [analyticsParams]="{ event_category: 'cta', event_label: 'Ver Todos os Serviços', content_type: 'internal_cta', page_section: 'home_services' }">
           <i class="fas fa-list me-2"></i>Ver Todos os Serviços
         </a>
       </div>
@@ -213,7 +219,8 @@
             </div>
           </div>
           <div class="about-actions">
-            <a routerLink="/sobre" class="btn btn-success btn-lg">
+            <a routerLink="/sobre" class="btn btn-success btn-lg" appTrackClick="select_content"
+               [analyticsParams]="{ event_category: 'cta', event_label: 'Conheça Nossa História', content_type: 'internal_cta', page_section: 'home_about' }">
               <i class="fas fa-info-circle me-2"></i>Conheça Nossa História
             </a>
           </div>
@@ -238,13 +245,16 @@
         <h3 class="cta-title">Pronto para agendar sua inspeção?</h3>
         <p class="cta-subtitle">Entre em contato conosco e garanta a regularização do seu veículo</p>
         <div class="cta-buttons">
-          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-light btn-lg">
+          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-light btn-lg" appTrackClick="generate_lead"
+             [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Curitiba', contact_method: 'whatsapp', location: 'curitiba', page_section: 'home_cta' }">
             <i class="fab fa-whatsapp me-2"></i>WhatsApp Curitiba
           </a>
-          <a href="https://api.whatsapp.com/send?phone=554135551300" class="btn btn-outline-light btn-lg">
+          <a href="https://api.whatsapp.com/send?phone=554135551300" class="btn btn-outline-light btn-lg" appTrackClick="generate_lead"
+             [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Campo Largo', contact_method: 'whatsapp', location: 'campo_largo', page_section: 'home_cta' }">
             <i class="fab fa-whatsapp me-2"></i>WhatsApp Campo Largo
           </a>
-          <a routerLink="/contato" class="btn btn-light btn-lg">
+          <a routerLink="/contato" class="btn btn-light btn-lg" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Outras Formas de Contato', content_type: 'internal_cta', page_section: 'home_cta' }">
             <i class="fas fa-phone me-2"></i>Outras Formas de Contato
           </a>
         </div>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,7 +1,8 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
   <div class="container">
     <!-- Logo -->
-    <a class="navbar-brand" routerLink="/inicio">
+    <a class="navbar-brand" routerLink="/inicio" appTrackClick="select_content"
+       [analyticsParams]="{ event_category: 'navigation', event_label: 'Logo', content_type: 'navbar_link' }">
       <img src="assets/logo.png" alt="Invmetro" class="navbar-logo me-2">
     </a>
 
@@ -15,32 +16,37 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
-          <a class="nav-link" routerLink="/inicio" routerLinkActive="active"
+          <a class="nav-link" routerLink="/inicio" routerLinkActive="active" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'navigation', event_label: 'Início', content_type: 'navbar_link' }"
              [routerLinkActiveOptions]="{exact: true}">
             <i class="fas fa-home me-1"></i>
             Início
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/servicos" routerLinkActive="active">
+          <a class="nav-link" routerLink="/servicos" routerLinkActive="active" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'navigation', event_label: 'Serviços', content_type: 'navbar_link' }">
             <i class="fas fa-tools me-1"></i>
             Serviços
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/sobre" routerLinkActive="active">
+          <a class="nav-link" routerLink="/sobre" routerLinkActive="active" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'navigation', event_label: 'A Invmetro', content_type: 'navbar_link' }">
             <i class="fas fa-info-circle me-1"></i>
             A Invmetro
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/contato" routerLinkActive="active">
+          <a class="nav-link" routerLink="/contato" routerLinkActive="active" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'navigation', event_label: 'Contato', content_type: 'navbar_cta' }">
             <i class="fas fa-phone me-1"></i>
             Contato
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/duvidas" routerLinkActive="active">
+          <a class="nav-link" routerLink="/duvidas" routerLinkActive="active" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'navigation', event_label: 'FAQ', content_type: 'navbar_link' }">
             <i class="fas fa-question-circle me-1"></i>
             FAQ
           </a>

--- a/src/app/servicos/servicos.component.html
+++ b/src/app/servicos/servicos.component.html
@@ -5,10 +5,12 @@
       <h1 class="hero-title">Nossos Serviços</h1>
       <p class="hero-subtitle">Soluções completas em inspeção veicular com qualidade e confiabilidade</p>
       <div class="hero-buttons">
-        <button (click)="scrollToSection('servicos')" class="btn btn-light">
+        <button (click)="scrollToSection('servicos')" class="btn btn-light" appTrackClick="select_content"
+                [analyticsParams]="{ event_category: 'cta', event_label: 'Ver Serviços', content_type: 'section_scroll', page_section: 'servicos_hero' }">
           <i class="fas fa-list me-2"></i>Ver Serviços
         </button>
-        <button (click)="scrollToSection('precos')" class="btn btn-outline-light">
+        <button (click)="scrollToSection('precos')" class="btn btn-outline-light" appTrackClick="select_content"
+                [analyticsParams]="{ event_category: 'cta', event_label: 'Consultar Preços', content_type: 'section_scroll', page_section: 'servicos_hero' }">
           <i class="fas fa-calculator me-2"></i>Consultar Preços
         </button>
       </div>
@@ -229,12 +231,14 @@
         <div class="pricing-navigation">
           <div class="nav nav-pills nav-justified" id="pricing-tabs" role="tablist">
             <button class="nav-link active" id="curitiba-tab" data-bs-toggle="pill" data-bs-target="#curitiba"
-                    type="button" role="tab" aria-controls="curitiba" aria-selected="true">
+                    type="button" role="tab" aria-controls="curitiba" aria-selected="true" appTrackClick="view_item"
+                    [analyticsParams]="{ event_category: 'pricing', event_label: 'Tabela Curitiba', item_name: 'precos_curitiba', location: 'curitiba' }">
               <i class="fas fa-building me-2"></i>
               Curitiba
             </button>
             <button class="nav-link" id="campo-largo-tab" data-bs-toggle="pill" data-bs-target="#campo-largo"
-                    type="button" role="tab" aria-controls="campo-largo" aria-selected="false">
+                    type="button" role="tab" aria-controls="campo-largo" aria-selected="false" appTrackClick="view_item"
+                    [analyticsParams]="{ event_category: 'pricing', event_label: 'Tabela Campo Largo', item_name: 'precos_campo_largo', location: 'campo_largo' }">
               <i class="fas fa-building me-2"></i>
               Campo Largo
             </button>
@@ -266,10 +270,12 @@
         <h3 class="cta-title">Precisa de mais informações?</h3>
         <p class="cta-subtitle">Entre em contato conosco para esclarecimentos sobre nossos serviços</p>
         <div class="cta-buttons">
-          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-light btn-lg">
+          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-light btn-lg" appTrackClick="generate_lead"
+             [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Serviços', contact_method: 'whatsapp', location: 'curitiba', page_section: 'servicos_cta' }">
             <i class="fab fa-whatsapp me-2"></i>WhatsApp
           </a>
-          <a routerLink="/contato" class="btn btn-outline-light btn-lg">
+          <a routerLink="/contato" class="btn btn-outline-light btn-lg" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Contato Serviços', content_type: 'internal_cta', page_section: 'servicos_cta' }">
             <i class="fas fa-phone me-2"></i>Contato
           </a>
         </div>

--- a/src/app/shared/analytics/analytics.service.ts
+++ b/src/app/shared/analytics/analytics.service.ts
@@ -1,0 +1,69 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+
+type AnalyticsParamValue = string | number | boolean | null | undefined;
+
+export interface AnalyticsEventParams {
+  [key: string]: AnalyticsParamValue;
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AnalyticsService {
+  private readonly measurementId = 'G-SFKFHXMY7W';
+
+  constructor(@Inject(DOCUMENT) private document: Document) {}
+
+  pageView(path: string, title = this.document.title): void {
+    this.gtag('config', this.measurementId, {
+      page_path: path,
+      page_title: title
+    });
+  }
+
+  trackEvent(eventName: string, params: AnalyticsEventParams = {}): void {
+    this.gtag('event', eventName, this.cleanParams({
+      page_path: this.currentPath(),
+      ...params
+    }));
+  }
+
+  private gtag(...args: unknown[]): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (typeof window.gtag === 'function') {
+      window.gtag(...args);
+      return;
+    }
+
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(args);
+  }
+
+  private currentPath(): string {
+    const location = this.document.location;
+    const hashRoute = location.hash.startsWith('#/') ? location.hash.slice(1) : '';
+
+    return hashRoute || `${location.pathname}${location.search}${location.hash}`;
+  }
+
+  private cleanParams(params: AnalyticsEventParams): AnalyticsEventParams {
+    return Object.entries(params).reduce<AnalyticsEventParams>((cleaned, [key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        cleaned[key] = value;
+      }
+
+      return cleaned;
+    }, {});
+  }
+}

--- a/src/app/shared/analytics/track-click.directive.ts
+++ b/src/app/shared/analytics/track-click.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, HostListener, Input } from '@angular/core';
+import { AnalyticsEventParams, AnalyticsService } from './analytics.service';
+
+@Directive({
+  selector: '[appTrackClick]',
+  standalone: false
+})
+export class TrackClickDirective {
+  @Input('appTrackClick') eventName = 'select_content';
+  @Input() analyticsParams: AnalyticsEventParams = {};
+
+  constructor(private analytics: AnalyticsService) {}
+
+  @HostListener('click')
+  trackClick(): void {
+    this.analytics.trackEvent(this.eventName, this.analyticsParams);
+  }
+}

--- a/src/app/sobre/sobre.component.html
+++ b/src/app/sobre/sobre.component.html
@@ -6,10 +6,12 @@
         <h1 class="display-4 fw-bold text-white mb-4">Sobre a Invmetro</h1>
         <p class="lead text-white-50 mb-4">Excelência em inspeção veicular desde 2009, com tecnologia e profissionalismo.</p>
         <div class="d-flex gap-3">
-          <button (click)="scrollToSection('nossa-historia')" class="btn btn-light">
+          <button (click)="scrollToSection('nossa-historia')" class="btn btn-light" appTrackClick="select_content"
+                  [analyticsParams]="{ event_category: 'cta', event_label: 'Nossa História', content_type: 'section_scroll', page_section: 'sobre_hero' }">
             <i class="fas fa-info-circle me-2"></i>Nossa História
           </button>
-          <a routerLink="/contato" class="btn btn-outline-light">
+          <a routerLink="/contato" class="btn btn-outline-light" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Nossas Unidades', content_type: 'internal_cta', page_section: 'sobre_hero' }">
             <i class="fas fa-map-marker-alt me-2"></i>Nossas Unidades
           </a>
         </div>
@@ -268,7 +270,8 @@
               </div>
               <div class="detail-content">
                 <strong>WhatsApp:</strong><br>
-                <a href="https://api.whatsapp.com/send?phone=554133573939" class="contact-link">(41) 3357-3939</a>
+                <a href="https://api.whatsapp.com/send?phone=554133573939" class="contact-link" appTrackClick="generate_lead"
+                   [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Sobre Curitiba', contact_method: 'whatsapp', location: 'curitiba', page_section: 'sobre_unidades' }">(41) 3357-3939</a>
               </div>
             </div>
           </div>
@@ -316,7 +319,8 @@
               </div>
               <div class="detail-content">
                 <strong>WhatsApp:</strong><br>
-                <a href="https://api.whatsapp.com/send?phone=554135551300" class="contact-link">(41) 3555-1300</a>
+                <a href="https://api.whatsapp.com/send?phone=554135551300" class="contact-link" appTrackClick="generate_lead"
+                   [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Sobre Campo Largo', contact_method: 'whatsapp', location: 'campo_largo', page_section: 'sobre_unidades' }">(41) 3555-1300</a>
               </div>
             </div>
           </div>
@@ -334,10 +338,12 @@
         <h3 class="h3 mb-3 text-white">Pronto para agendar sua inspeção?</h3>
         <p class="lead mb-4 text-white-50">Entre em contato conosco e garante a segurança do seu veículo</p>
         <div class="d-flex gap-3 justify-content-center">
-          <a routerLink="/contato" class="btn btn-light">
+          <a routerLink="/contato" class="btn btn-light" appTrackClick="select_content"
+             [analyticsParams]="{ event_category: 'cta', event_label: 'Entre em Contato Sobre', content_type: 'internal_cta', page_section: 'sobre_cta' }">
             <i class="fas fa-phone me-2"></i>Entre em Contato
           </a>
-          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-outline-light">
+          <a href="https://api.whatsapp.com/send?phone=554133573939" class="btn btn-outline-light" appTrackClick="generate_lead"
+             [analyticsParams]="{ event_category: 'lead', event_label: 'WhatsApp Sobre CTA', contact_method: 'whatsapp', location: 'curitiba', page_section: 'sobre_cta' }">
             <i class="fab fa-whatsapp me-2"></i>WhatsApp
           </a>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-SFKFHXMY7W');
+  gtag('config', 'G-SFKFHXMY7W', { send_page_view: false });
 </script>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- centralizes GA4 tracking in an Angular analytics service
- adds SPA pageview tracking on route navigation without duplicating the initial GA4 pageview
- tracks lead and intent events across WhatsApp, e-mail, navbar, service CTAs, pricing tabs, and FAQ interactions

## Analytics events
- generate_lead for WhatsApp and e-mail clicks
- select_content for navigation, internal CTAs, and section scroll CTAs
- view_item for pricing tab selection
- faq_open for FAQ accordion interactions

## Validation
- ng build --configuration production --base-href=/